### PR TITLE
feat: Add mechanism for flagging that a request is within multitenanted context

### DIFF
--- a/src/Database/Eloquent/Concerns/IsTenant.php
+++ b/src/Database/Eloquent/Concerns/IsTenant.php
@@ -27,6 +27,7 @@ trait IsTenant
      */
     public function getTenantIdentifier(): string
     {
+        /** @phpstan-ignore return.type */
         return $this->getAttribute($this->getTenantIdentifierName());
     }
 
@@ -57,6 +58,7 @@ trait IsTenant
      */
     public function getTenantKey(): int|string
     {
+        /** @phpstan-ignore return.type */
         return $this->getKey();
     }
 

--- a/src/Sprout.php
+++ b/src/Sprout.php
@@ -36,6 +36,11 @@ final class Sprout
     private array $overrides = [];
 
     /**
+     * @var bool
+     */
+    private bool $withinContext = false;
+
+    /**
      * Create a new instance
      *
      * @param \Illuminate\Contracts\Foundation\Application $app
@@ -74,6 +79,8 @@ final class Sprout
         if ($this->getCurrentTenancy() !== $tenancy) {
             $this->tenancies[] = $tenancy;
         }
+
+        $this->markAsInContext();
     }
 
     /**
@@ -209,5 +216,39 @@ final class Sprout
         $enabledHooks = $this->config('hooks', []);
 
         return in_array($hook, $enabledHooks, true);
+    }
+
+    /**
+     * Flag the current request as being within multitenanted context
+     *
+     * @return static
+     */
+    public function markAsInContext(): self
+    {
+        $this->withinContext = true;
+
+        return $this;
+    }
+
+    /**
+     * Flag the current request as being outside multitenanted context
+     *
+     * @return static
+     */
+    public function maskAsOutsideContext(): self
+    {
+        $this->withinContext = false;
+
+        return $this;
+    }
+
+    /**
+     * Check if the current request is within multitenanted context
+     *
+     * @return bool
+     */
+    public function withinContext():bool
+    {
+        return $this->withinContext;
     }
 }

--- a/tests/Http/Resolvers/SubdomainResolverTest.php
+++ b/tests/Http/Resolvers/SubdomainResolverTest.php
@@ -14,6 +14,7 @@ use Sprout\Attributes\CurrentTenant;
 use Sprout\Contracts\Tenant;
 use Workbench\App\Models\TenantModel;
 use function Sprout\resolver;
+use function Sprout\sprout;
 
 class SubdomainResolverTest extends TestCase
 {
@@ -86,6 +87,7 @@ class SubdomainResolverTest extends TestCase
 
         $result->assertOk();
         $result->assertContent((string)$tenant->getTenantKey());
+        $this->assertTrue(sprout()->withinContext());
     }
 
     #[Test]
@@ -95,6 +97,7 @@ class SubdomainResolverTest extends TestCase
 
         $result->assertOk();
         $result->assertContent('no');
+        $this->assertFalse(sprout()->withinContext());
     }
 
     #[Test]

--- a/tests/Providers/DatabaseTenantProviderTest.php
+++ b/tests/Providers/DatabaseTenantProviderTest.php
@@ -24,7 +24,10 @@ class DatabaseTenantProviderTest extends TestCase
     protected function defineEnvironment($app): void
     {
         tap($app['config'], static function (Repository $config) {
-            $config->set('multitenancy.providers.backup.table', 'tenants');
+            $config->set('multitenancy.providers.backup', [
+                'driver' => 'database',
+                'table'  => 'tenants',
+            ]);
         });
     }
 


### PR DESCRIPTION
This PR adds a flag for marking the current request as being within multitenanted context. This is primarily so that automated implicit functionality can be skipped if it shouldn't be running.

Fixes both #56 and #57 