### PR TITLE
fix: Restrict eloquent scope and observer functionality based on multitenanted context

### DIFF
--- a/src/Database/Eloquent/Observers/BelongsToManyTenantsObserver.php
+++ b/src/Database/Eloquent/Observers/BelongsToManyTenantsObserver.php
@@ -10,6 +10,7 @@ use Sprout\Contracts\Tenant;
 use Sprout\Exceptions\TenantMismatch;
 use Sprout\Exceptions\TenantMissing;
 use Sprout\TenancyOptions;
+use function Sprout\sprout;
 
 /**
  * Belongs to Many Tenants Observer
@@ -151,6 +152,10 @@ class BelongsToManyTenantsObserver
      */
     public function created(Model $model): void
     {
+        if (! sprout()->withinContext()) {
+            return;
+        }
+
         /**
          * @var \Illuminate\Database\Eloquent\Relations\BelongsToMany<ChildModel, TenantModel> $relation
          * @phpstan-ignore-next-line
@@ -199,6 +204,10 @@ class BelongsToManyTenantsObserver
      */
     public function retrieved(Model $model): void
     {
+        if (! sprout()->withinContext()) {
+            return;
+        }
+
         /**
          * @var \Illuminate\Database\Eloquent\Relations\BelongsToMany<ChildModel, TenantModel> $relation
          * @phpstan-ignore-next-line

--- a/src/Database/Eloquent/Observers/BelongsToTenantObserver.php
+++ b/src/Database/Eloquent/Observers/BelongsToTenantObserver.php
@@ -10,6 +10,7 @@ use Sprout\Contracts\Tenant;
 use Sprout\Exceptions\TenantMismatch;
 use Sprout\Exceptions\TenantMissing;
 use Sprout\TenancyOptions;
+use function Sprout\sprout;
 
 /**
  * Belongs to Tenant Observer
@@ -134,6 +135,10 @@ class BelongsToTenantObserver
      */
     public function creating(Model $model): bool
     {
+        if (! sprout()->withinContext()) {
+            return true;
+        }
+
         /**
          * @var \Illuminate\Database\Eloquent\Relations\BelongsTo<ChildModel, TenantModel> $relation
          * @phpstan-ignore-next-line
@@ -175,6 +180,10 @@ class BelongsToTenantObserver
      */
     public function retrieved(Model $model): void
     {
+        if (! sprout()->withinContext()) {
+            return;
+        }
+
         /**
          * @var \Illuminate\Database\Eloquent\Relations\BelongsTo<ChildModel, TenantModel> $relation
          * @phpstan-ignore-next-line

--- a/src/Database/Eloquent/Scopes/BelongsToManyTenantsScope.php
+++ b/src/Database/Eloquent/Scopes/BelongsToManyTenantsScope.php
@@ -6,6 +6,7 @@ namespace Sprout\Database\Eloquent\Scopes;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Sprout\Exceptions\TenantMissing;
+use function Sprout\sprout;
 
 /**
  * Belongs to many Tenants Scope
@@ -38,6 +39,10 @@ final class BelongsToManyTenantsScope extends TenantChildScope
      */
     public function apply(Builder $builder, Model $model): void
     {
+        if (! sprout()->withinContext()) {
+            return;
+        }
+
         /** @phpstan-ignore-next-line */
         $tenancy = $model->getTenancy();
 

--- a/src/Database/Eloquent/Scopes/BelongsToTenantScope.php
+++ b/src/Database/Eloquent/Scopes/BelongsToTenantScope.php
@@ -6,6 +6,7 @@ namespace Sprout\Database\Eloquent\Scopes;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Sprout\Exceptions\TenantMissing;
+use function Sprout\sprout;
 
 /**
  * Belongs to Tenant Scope
@@ -38,6 +39,10 @@ final class BelongsToTenantScope extends TenantChildScope
      */
     public function apply(Builder $builder, Model $model): void
     {
+        if (! sprout()->withinContext()) {
+            return;
+        }
+
         /** @phpstan-ignore-next-line */
         $tenancy = $model->getTenancy();
 

--- a/src/Database/Eloquent/Scopes/TenantChildScope.php
+++ b/src/Database/Eloquent/Scopes/TenantChildScope.php
@@ -20,6 +20,11 @@ use Illuminate\Database\Eloquent\Scope;
 abstract class TenantChildScope implements Scope
 {
     /**
+     * @var array<string, string>
+     */
+    protected array $extensions = [];
+
+    /**
      * Extend the query builder with the necessary macros
      *
      * @template ModelClass of \Illuminate\Database\Eloquent\Model
@@ -34,5 +39,9 @@ abstract class TenantChildScope implements Scope
             /** @phpstan-ignore-next-line */
             return $builder->withoutGlobalScope($this);
         });
+
+        foreach ($this->extensions as $macro => $method) {
+            $builder->macro($macro, $this->$method(...));
+        }
     }
 }

--- a/tests/Database/Eloquent/BelongsToManyTenantsTest.php
+++ b/tests/Database/Eloquent/BelongsToManyTenantsTest.php
@@ -88,6 +88,16 @@ class BelongsToManyTenantsTest extends TestCase
     }
 
     #[Test]
+    public function doesNotAutomaticallyAssociateWithTenantWhenCreatingWhenOutsideMultitenantedContext(): void
+    {
+        $child = TenantChildren::factory()->create();
+
+        $this->assertTrue($child->exists);
+        $this->assertFalse($child->relationLoaded('tenants'));
+        $this->assertTrue($child->tenants->isEmpty());
+    }
+
+    #[Test]
     public function throwsAnExceptionIfTheresNoTenantAndTheTenantIsNotOptionalWhenCreating(): void
     {
         sprout()->setCurrentTenancy(app(TenancyManager::class)->get());
@@ -98,6 +108,15 @@ class BelongsToManyTenantsTest extends TestCase
         );
 
         TenantChildren::factory()->create();
+    }
+
+    #[Test]
+    public function doesNotThrowAnExceptionIfTheresNoTenantAndTheTenantIsNotOptionalWhenCreatingWhenOutsideMultitenantedContext(): void
+    {
+        $model = TenantChildren::factory()->create();
+
+        $this->assertNotNull($model);
+        $this->assertTrue($model->exists);
     }
 
     #[Test]
@@ -160,6 +179,16 @@ class BelongsToManyTenantsTest extends TestCase
         $this->assertTrue($child->exists);
         $this->assertTrue($child->relationLoaded('tenants'));
         $this->assertNotNull($child->getRelation('tenants')->first(fn (Model $model) => $model->is($tenant)));
+    }
+
+    #[Test]
+    public function doesNotAutomaticallyPopulateTheTenantRelationWhenHydratingWhenOutsideMultitenantedContext(): void
+    {
+
+        $child = TenantChildren::query()->find(TenantChildren::factory()->create()->getKey());
+
+        $this->assertTrue($child->exists);
+        $this->assertFalse($child->relationLoaded('tenants'));
     }
 
     #[Test]

--- a/tests/Database/Eloquent/BelongsToManyTenantsTest.php
+++ b/tests/Database/Eloquent/BelongsToManyTenantsTest.php
@@ -23,6 +23,7 @@ use Workbench\App\Models\TenantChildOptional;
 use Workbench\App\Models\TenantChildren;
 use Workbench\App\Models\TenantChildrenOptional;
 use Workbench\App\Models\TenantModel;
+use function Sprout\sprout;
 
 #[Group('database'), Group('eloquent')]
 class BelongsToManyTenantsTest extends TestCase
@@ -73,7 +74,11 @@ class BelongsToManyTenantsTest extends TestCase
     {
         $tenant = TenantModel::factory()->create();
 
-        app(TenancyManager::class)->get()->setTenant($tenant);
+        $tenancy = app(TenancyManager::class)->get();
+
+        sprout()->setCurrentTenancy($tenancy);
+
+        $tenancy->setTenant($tenant);
 
         $child = TenantChildren::factory()->create();
 
@@ -85,6 +90,8 @@ class BelongsToManyTenantsTest extends TestCase
     #[Test]
     public function throwsAnExceptionIfTheresNoTenantAndTheTenantIsNotOptionalWhenCreating(): void
     {
+        sprout()->setCurrentTenancy(app(TenancyManager::class)->get());
+
         $this->expectException(TenantMissing::class);
         $this->expectExceptionMessage(
             'There is no current tenant for tenancy [tenants]'
@@ -142,7 +149,11 @@ class BelongsToManyTenantsTest extends TestCase
     {
         $tenant = TenantModel::factory()->create();
 
-        app(TenancyManager::class)->get()->setTenant($tenant);
+        $tenancy = app(TenancyManager::class)->get();
+
+        sprout()->setCurrentTenancy($tenancy);
+
+        $tenancy->setTenant($tenant);
 
         $child = TenantChildren::query()->find(TenantChildren::factory()->create()->getKey());
 
@@ -157,6 +168,8 @@ class BelongsToManyTenantsTest extends TestCase
         $tenant = TenantModel::factory()->create();
 
         $tenancy = app(TenancyManager::class)->get();
+
+        sprout()->setCurrentTenancy($tenancy);
 
         $tenancy->setTenant($tenant);
 
@@ -223,7 +236,10 @@ class BelongsToManyTenantsTest extends TestCase
 
         $tenancy = app(TenancyManager::class)->get();
 
+        sprout()->setCurrentTenancy($tenancy);
+
         $tenancy->setTenant($tenant);
+
         $tenancy->addOption(TenancyOptions::throwIfNotRelated());
 
         $child = TenantChildren::factory()->create();
@@ -248,7 +264,10 @@ class BelongsToManyTenantsTest extends TestCase
 
         $tenancy = app(TenancyManager::class)->get();
 
+        sprout()->setCurrentTenancy($tenancy);
+
         $tenancy->setTenant($tenant);
+
         $tenancy->removeOption(TenancyOptions::throwIfNotRelated());
 
         $child = TenantChildren::factory()->create();
@@ -269,6 +288,8 @@ class BelongsToManyTenantsTest extends TestCase
         $tenant = TenantModel::factory()->create();
 
         $tenancy = app(TenancyManager::class)->get();
+
+        sprout()->setCurrentTenancy($tenancy);
 
         $tenancy->setTenant($tenant);
 

--- a/tests/Database/Eloquent/BelongsToTenantTest.php
+++ b/tests/Database/Eloquent/BelongsToTenantTest.php
@@ -86,6 +86,16 @@ class BelongsToTenantTest extends TestCase
     }
 
     #[Test]
+    public function doesNotAutomaticallyAssociateWithTenantWhenCreatingWhenOutsideMultitenantedContext(): void
+    {
+        $child = TenantChild::factory()->create();
+
+        $this->assertTrue($child->exists);
+        $this->assertFalse($child->relationLoaded('tenant'));
+        $this->assertNull($child->tenant);
+    }
+
+    #[Test]
     public function throwsAnExceptionIfTheresNoTenantAndTheTenantIsNotOptionalWhenCreating(): void
     {
         sprout()->setCurrentTenancy(app(TenancyManager::class)->get());
@@ -96,6 +106,16 @@ class BelongsToTenantTest extends TestCase
         );
 
         TenantChild::factory()->create();
+    }
+
+    #[Test]
+    public function doesNotThrowAnExceptionIfTheresNoTenantAndTheTenantIsNotOptionalWhenCreatingWhenOutsideMultitenantedContext(): void
+    {
+        $child = TenantChild::factory()->create();
+
+        $this->assertTrue($child->exists);
+        $this->assertFalse($child->relationLoaded('tenant'));
+        $this->assertNull($child->tenant);
     }
 
     #[Test]
@@ -196,6 +216,15 @@ class BelongsToTenantTest extends TestCase
         $this->assertTrue($child->relationLoaded('tenant'));
         $this->assertNotNull($child->getRelation('tenant'));
         $this->assertTrue($child->getRelation('tenant')->is($tenant));
+    }
+
+    #[Test]
+    public function doesNotAutomaticallyPopulateTheTenantRelationWhenHydratingWhenOutsideMultitenantedCContext(): void
+    {
+        $child = TenantChild::query()->find(TenantChild::factory()->create()->getKey());
+
+        $this->assertTrue($child->exists);
+        $this->assertFalse($child->relationLoaded('tenant'));
     }
 
     #[Test]

--- a/tests/Database/Eloquent/BelongsToTenantTest.php
+++ b/tests/Database/Eloquent/BelongsToTenantTest.php
@@ -21,6 +21,7 @@ use Sprout\TenancyOptions;
 use Workbench\App\Models\TenantChild;
 use Workbench\App\Models\TenantChildOptional;
 use Workbench\App\Models\TenantModel;
+use function Sprout\sprout;
 
 #[Group('database'), Group('eloquent')]
 class BelongsToTenantTest extends TestCase
@@ -71,7 +72,11 @@ class BelongsToTenantTest extends TestCase
     {
         $tenant = TenantModel::factory()->create();
 
-        app(TenancyManager::class)->get()->setTenant($tenant);
+        $tenancy = app(TenancyManager::class)->get();
+
+        sprout()->setCurrentTenancy($tenancy);
+
+        $tenancy->setTenant($tenant);
 
         $child = TenantChild::factory()->create();
 
@@ -83,6 +88,8 @@ class BelongsToTenantTest extends TestCase
     #[Test]
     public function throwsAnExceptionIfTheresNoTenantAndTheTenantIsNotOptionalWhenCreating(): void
     {
+        sprout()->setCurrentTenancy(app(TenancyManager::class)->get());
+
         $this->expectException(TenantMissing::class);
         $this->expectExceptionMessage(
             'There is no current tenant for tenancy [tenants]'
@@ -138,7 +145,10 @@ class BelongsToTenantTest extends TestCase
 
         $tenancy = app(TenancyManager::class)->get();
 
+        sprout()->setCurrentTenancy($tenancy);
+
         $tenancy->setTenant($tenant);
+
         $tenancy->addOption(TenancyOptions::throwIfNotRelated());
 
         $this->expectException(TenantMismatch::class);
@@ -174,7 +184,11 @@ class BelongsToTenantTest extends TestCase
     {
         $tenant = TenantModel::factory()->create();
 
-        app(TenancyManager::class)->get()->setTenant($tenant);
+        $tenancy = app(TenancyManager::class)->get();
+
+        sprout()->setCurrentTenancy($tenancy);
+
+        $tenancy->setTenant($tenant);
 
         $child = TenantChild::query()->find(TenantChild::factory()->create()->getKey());
 
@@ -207,6 +221,8 @@ class BelongsToTenantTest extends TestCase
         $tenant = TenantModel::factory()->create();
 
         $tenancy = app(TenancyManager::class)->get();
+
+        sprout()->setCurrentTenancy($tenancy);
 
         $tenancy->setTenant($tenant);
 
@@ -273,7 +289,10 @@ class BelongsToTenantTest extends TestCase
 
         $tenancy = app(TenancyManager::class)->get();
 
+        sprout()->setCurrentTenancy($tenancy);
+
         $tenancy->setTenant($tenant);
+
         $tenancy->addOption(TenancyOptions::throwIfNotRelated());
 
         $child = TenantChild::factory()->create();
@@ -298,7 +317,10 @@ class BelongsToTenantTest extends TestCase
 
         $tenancy = app(TenancyManager::class)->get();
 
+        sprout()->setCurrentTenancy($tenancy);
+
         $tenancy->setTenant($tenant);
+
         $tenancy->removeOption(TenancyOptions::throwIfNotRelated());
 
         $child = TenantChild::factory()->create();
@@ -319,6 +341,8 @@ class BelongsToTenantTest extends TestCase
         $tenant = TenantModel::factory()->create();
 
         $tenancy = app(TenancyManager::class)->get();
+
+        sprout()->setCurrentTenancy($tenancy);
 
         $tenancy->setTenant($tenant);
 


### PR DESCRIPTION
This PR addresses #65 by having all the tenant-child scopes and observers exit only if outside multitenanted context.