### PR TITLE
feat: Add service override events

### DIFF
--- a/src/Concerns/HandlesServiceOverrides.php
+++ b/src/Concerns/HandlesServiceOverrides.php
@@ -9,6 +9,10 @@ use Sprout\Contracts\DeferrableServiceOverride;
 use Sprout\Contracts\ServiceOverride;
 use Sprout\Contracts\Tenancy;
 use Sprout\Contracts\Tenant;
+use Sprout\Events\ServiceOverrideBooted;
+use Sprout\Events\ServiceOverrideProcessed;
+use Sprout\Events\ServiceOverrideProcessing;
+use Sprout\Events\ServiceOverrideRegistered;
 
 trait HandlesServiceOverrides
 {
@@ -65,6 +69,8 @@ trait HandlesServiceOverrides
         // Flag the service override as being registered
         $this->registeredOverrides[] = $overrideClass;
 
+        ServiceOverrideRegistered::dispatch($overrideClass);
+
         if (is_subclass_of($overrideClass, DeferrableServiceOverride::class)) {
             $this->registerDeferrableOverride($overrideClass);
         } else {
@@ -88,6 +94,8 @@ trait HandlesServiceOverrides
      */
     protected function processOverride(string $overrideClass): static
     {
+        ServiceOverrideProcessing::dispatch($overrideClass);
+
         // Create a new instance of the override
         $override = $this->app->make($overrideClass);
 
@@ -106,6 +114,8 @@ trait HandlesServiceOverrides
                 $this->bootOverride($overrideClass);
             }
         }
+
+        ServiceOverrideProcessed::dispatch($override);
 
         return $this;
     }
@@ -218,6 +228,8 @@ trait HandlesServiceOverrides
 
         $override->boot($this->app, $this);
         $this->bootedOverrides[$overrideClass] = true;
+
+        ServiceOverrideBooted::dispatch($override);
     }
 
     /**

--- a/src/Events/ServiceOverrideBooted.php
+++ b/src/Events/ServiceOverrideBooted.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Events;
+
+use Sprout\Contracts\ServiceOverride as ServiceOverrideClass;
+
+/**
+ * Service Override Booted Event
+ *
+ * This event is dispatched after a service override has been booted.
+ *
+ * @template ServiceOverrideClass of \Sprout\Contracts\ServiceOverride
+ *
+ * @package Overrides
+ *
+ * @method static self dispatch(object $override)
+ * @method static self dispatchIf(bool $boolean, object $override)
+ * @method static self dispatchUnless(bool $boolean, object $override)
+ */
+final class ServiceOverrideBooted extends ServiceOverrideEvent
+{
+    /**
+     * @var object<\Sprout\Contracts\ServiceOverride>
+     * @phpstan-var ServiceOverrideClass
+     */
+    public readonly object $override;
+
+    /**
+     * @param object<\Sprout\Contracts\ServiceOverride> $override
+     *
+     * @phpstan-param ServiceOverrideClass              $override
+     */
+    public function __construct(object $override)
+    {
+        $this->override = $override;
+    }
+}

--- a/src/Events/ServiceOverrideEvent.php
+++ b/src/Events/ServiceOverrideEvent.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Service Override Event
+ *
+ * This is a base event class for the service override events.
+ *
+ * @package Overrides
+ */
+abstract class ServiceOverrideEvent
+{
+    use Dispatchable;
+}

--- a/src/Events/ServiceOverrideProcessed.php
+++ b/src/Events/ServiceOverrideProcessed.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Events;
+
+/**
+ * Service Override Processed Event
+ *
+ * This event is dispatched after a service override has been processed.
+ *
+ * @template ServiceOverrideClass of \Sprout\Contracts\ServiceOverride
+ *
+ * @package Overrides
+ *
+ * @method static self dispatch(object $override)
+ * @method static self dispatchIf(bool $boolean, object $override)
+ * @method static self dispatchUnless(bool $boolean, object $override)
+ */
+final class ServiceOverrideProcessed extends ServiceOverrideEvent
+{
+    /**
+     * @var object<\Sprout\Contracts\ServiceOverride>
+     * @phpstan-var ServiceOverrideClass
+     */
+    public readonly object $override;
+
+    /**
+     * @param object<\Sprout\Contracts\ServiceOverride> $override
+     *
+     * @phpstan-param ServiceOverrideClass              $override
+     */
+    public function __construct(object $override)
+    {
+        $this->override = $override;
+    }
+}

--- a/src/Events/ServiceOverrideProcessing.php
+++ b/src/Events/ServiceOverrideProcessing.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Events;
+
+/**
+ * Service Override Processing Event
+ *
+ * This event is dispatched before a service override is processed.
+ *
+ * @package Overrides
+ *
+ * @method static self dispatch(string $override)
+ * @method static self dispatchIf(bool $boolean, string $override)
+ * @method static self dispatchUnless(bool $boolean, string $override)
+ */
+final class ServiceOverrideProcessing extends ServiceOverrideEvent
+{
+    /**
+     * @var class-string<\Sprout\Contracts\ServiceOverride>
+     */
+    public readonly string $override;
+
+    /**
+     * @param class-string<\Sprout\Contracts\ServiceOverride> $override
+     */
+    public function __construct(string $override)
+    {
+        $this->override = $override;
+    }
+}

--- a/src/Events/ServiceOverrideRegistered.php
+++ b/src/Events/ServiceOverrideRegistered.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Events;
+
+/**
+ * Service Override Registered Event
+ *
+ * This event is dispatched when a service override is registered with
+ * Sprout.
+ *
+ * @package Overrides
+ *
+ * @method static self dispatch(string $override)
+ * @method static self dispatchIf(bool $boolean, string $override)
+ * @method static self dispatchUnless(bool $boolean, string $override)
+ */
+final class ServiceOverrideRegistered extends ServiceOverrideEvent
+{
+    /**
+     * @var class-string<\Sprout\Contracts\ServiceOverride>
+     */
+    public readonly string $override;
+
+    /**
+     * @param class-string<\Sprout\Contracts\ServiceOverride> $override
+     */
+    public function __construct(string $override)
+    {
+        $this->override = $override;
+    }
+}


### PR DESCRIPTION
This PR adds events for the following cases:

- When a service override is registered `ServiceOverrideRegistered`
- When a service override is being processed `ServiceOverrideProcessing`
- When a service override has been processed `ServiceOverrideProcessed`
- When a service override has been booted `ServiceOverrideBooted`

Completes #70 