### PR TITLE
fix: Fix incorrect typing of 'same_site' cookie option

### DIFF
--- a/src/Http/Resolvers/CookieIdentityResolver.php
+++ b/src/Http/Resolvers/CookieIdentityResolver.php
@@ -203,12 +203,12 @@ final class CookieIdentityResolver extends BaseIdentityResolver
             $details['secure'] = $this->options['secure'];
         }
 
-        if (isset($this->options['httpOnly'])) {
-            $details['httpOnly'] = $this->options['httpOnly'];
+        if (isset($this->options['http_only'])) {
+            $details['http_only'] = $this->options['http_only'];
         }
 
-        if (isset($this->options['sameSite'])) {
-            $details['sameSite'] = $this->options['sameSite'];
+        if (isset($this->options['same_site'])) {
+            $details['same_site'] = $this->options['same_site'];
         }
 
         return $details;

--- a/src/Overrides/CookieOverride.php
+++ b/src/Overrides/CookieOverride.php
@@ -48,7 +48,7 @@ final class CookieOverride implements ServiceOverride, DeferrableServiceOverride
         $path     = settings()->getUrlPath(config('session.path') ?? '/');             // @phpstan-ignore-line
         $domain   = settings()->getUrlDomain(config('session.domain'));                // @phpstan-ignore-line
         $secure   = settings()->shouldCookieBeSecure(config('session.secure', false)); // @phpstan-ignore-line
-        $sameSite = settings()->shouldCookeBeSameSite(config('session.same_site'));    // @phpstan-ignore-line
+        $sameSite = settings()->getCookieSameSite(config('session.same_site'));        // @phpstan-ignore-line
 
         /**
          * This is here to make PHPStan quiet down

--- a/src/Overrides/SessionOverride.php
+++ b/src/Overrides/SessionOverride.php
@@ -110,7 +110,7 @@ final class SessionOverride implements BootableServiceOverride, DeferrableServic
         }
 
         if ($settings->has(Settings::COOKIE_SAME_SITE)) {
-            $config->set('session.same_site', $settings->shouldCookeBeSameSite());
+            $config->set('session.same_site', $settings->getCookieSameSite());
         }
 
         $config->set('session.cookie', $this->getCookieName($tenancy, $tenant));

--- a/src/Support/SettingsRepository.php
+++ b/src/Support/SettingsRepository.php
@@ -49,14 +49,22 @@ final class SettingsRepository extends Repository
         return $this->boolean(Settings::COOKIE_SECURE, $default);
     }
 
-    public function setCookieSameSite(bool $sameSite): void
+    public function setCookieSameSite(?string $sameSite): void
     {
         $this->set(Settings::COOKIE_SAME_SITE, $sameSite);
     }
 
-    public function shouldCookeBeSameSite(?bool $default = null): bool
+    public function getCookieSameSite(?string $default = null): ?string
     {
-        return $this->boolean(Settings::COOKIE_SAME_SITE, $default);
+        /**
+         * This is only here because the config repository has terrible support
+         * for typing, as you'd expect.
+         *
+         * @var string|null $sameSite
+         */
+        $sameSite = $this->get(Settings::COOKIE_SAME_SITE, $default);
+
+        return $sameSite;
     }
 
     public function doNotOverrideTheDatabase(): void


### PR DESCRIPTION
This fixes #80 by setting the expected typing for all occurrences of `same_site` to be `string|null`/ `?string`