### PR TITLE
refactor: Modify service override registration so they're mapped to a "service"

### DIFF
--- a/resources/config/sprout.php
+++ b/resources/config/sprout.php
@@ -1,5 +1,7 @@
 <?php
 
+use Sprout\Support\Services;
+
 return [
 
     /*
@@ -53,22 +55,22 @@ return [
     'services' => [
         // This will override the storage by introducing a 'sprout' driver
         // that wraps any other storage drive in a tenant resource subdirectory.
-        \Sprout\Overrides\StorageOverride::class,
+        Services::STORAGE => \Sprout\Overrides\StorageOverride::class,
         // This will hydrate tenants when running jobs, based on the current
         // context.
-        \Sprout\Overrides\JobOverride::class,
+        Services::JOB     => \Sprout\Overrides\JobOverride::class,
         // This will override the cache by introducing a 'sprout' driver
         // that adds a prefix to cache stores for the current tenant.
-        \Sprout\Overrides\CacheOverride::class,
+        Services::CACHE   => \Sprout\Overrides\CacheOverride::class,
         // This is a simple override that removes all currently resolved
         // guards to prevent user auth leaking.
-        \Sprout\Overrides\AuthOverride::class,
+        Services::AUTH    => \Sprout\Overrides\AuthOverride::class,
         // This will override the cookie settings so that all created cookies
         // are specific to the tenant.
-        \Sprout\Overrides\CookieOverride::class,
+        Services::COOKIE  => \Sprout\Overrides\CookieOverride::class,
         // This will override the session by introducing a 'sprout' driver
         // that wraps any other session store.
-        \Sprout\Overrides\SessionOverride::class,
+        Services::SESSION => \Sprout\Overrides\SessionOverride::class,
     ],
 
 ];

--- a/src/SproutServiceProvider.php
+++ b/src/SproutServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Routing\Events\RouteMatched;
 use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
+use RuntimeException;
 use Sprout\Events\CurrentTenantChanged;
 use Sprout\Http\Middleware\TenantRoutes;
 use Sprout\Http\RouterMethods;
@@ -106,11 +107,15 @@ class SproutServiceProvider extends ServiceProvider
 
     private function registerServiceOverrides(): void
     {
-        /** @var array<class-string<\Sprout\Contracts\ServiceOverride>> $overrides */
+        /** @var array<string, class-string<\Sprout\Contracts\ServiceOverride>> $overrides */
         $overrides = config('sprout.services', []);
 
-        foreach ($overrides as $overrideClass) {
-            $this->sprout->registerOverride($overrideClass);
+        foreach ($overrides as $service => $overrideClass) {
+            if (! is_string($service)) {
+                throw new RuntimeException('Service overrides must be registered against a "service"');
+            }
+
+            $this->sprout->registerOverride($service, $overrideClass);
         }
     }
 

--- a/src/Support/Services.php
+++ b/src/Support/Services.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Support;
+
+final class Services
+{
+    public const AUTH = 'auth';
+
+    public const CACHE = 'cache';
+
+    public const COOKIE = 'cookie';
+
+    public const JOB = 'job';
+
+    public const SESSION = 'session';
+
+    public const STORAGE = 'storage';
+}

--- a/tests/Unit/Overrides/AuthOverrideTest.php
+++ b/tests/Unit/Overrides/AuthOverrideTest.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Tests\Unit\Overrides;
+
+use Illuminate\Config\Repository;
+use PHPUnit\Framework\Attributes\Test;
+use Sprout\Contracts\BootableServiceOverride;
+use Sprout\Contracts\DeferrableServiceOverride;
+use Sprout\Overrides\Auth\TenantAwarePasswordBrokerManager;
+use Sprout\Overrides\AuthOverride;
+use Sprout\Support\Services;
+use Sprout\Tests\Unit\UnitTestCase;
+use function Sprout\sprout;
+
+class AuthOverrideTest extends UnitTestCase
+{
+    protected function defineEnvironment($app): void
+    {
+        tap($app['config'], static function (Repository $config) {
+            $config->set('sprout.services', []);
+        });
+    }
+
+    #[Test]
+    public function isBuiltCorrectly(): void
+    {
+        $this->assertTrue(is_subclass_of(AuthOverride::class, BootableServiceOverride::class));
+        $this->assertFalse(is_subclass_of(AuthOverride::class, DeferrableServiceOverride::class));
+    }
+
+    #[Test]
+    public function isRegisteredWithSproutCorrectly(): void
+    {
+        $sprout = sprout();
+
+        $sprout->registerOverride(Services::AUTH, AuthOverride::class);
+
+        $this->assertTrue($sprout->hasRegisteredOverride(AuthOverride::class));
+        $this->assertTrue($sprout->isBootableOverride(AuthOverride::class));
+        $this->assertFalse($sprout->isDeferrableOverride(AuthOverride::class));
+    }
+
+    #[Test]
+    public function isBootedCorrectly(): void
+    {
+        $sprout = sprout();
+
+        $sprout->registerOverride(Services::AUTH, AuthOverride::class);
+
+        $this->assertFalse(app()->isDeferredService('auth.password'));
+        $this->assertTrue(app()->bound('auth.password'));
+        $this->assertFalse(app()->resolved('auth.password'));
+        $this->assertFalse(app()->resolved('auth.password.broker'));
+        $this->assertInstanceOf(TenantAwarePasswordBrokerManager::class, app()->make('auth.password'));
+        $this->assertTrue(app()->resolved('auth.password'));
+        $this->assertFalse(app()->resolved('auth.password.broker'));
+    }
+}

--- a/tests/_Original/Http/Resolvers/SessionResolverTest.php
+++ b/tests/_Original/Http/Resolvers/SessionResolverTest.php
@@ -20,6 +20,7 @@ use Sprout\Overrides\CookieOverride;
 use Sprout\Overrides\JobOverride;
 use Sprout\Overrides\SessionOverride;
 use Sprout\Overrides\StorageOverride;
+use Sprout\Support\Services;
 use Workbench\App\Models\TenantModel;
 use function Sprout\sprout;
 
@@ -108,7 +109,7 @@ class SessionResolverTest extends TestCase
     #[Test]
     public function throwsExceptionIfSessionOverrideIsEnabled(): void
     {
-        sprout()->registerOverride(SessionOverride::class);
+        sprout()->registerOverride(Services::SESSION, SessionOverride::class);
         $tenant = TenantModel::factory()->createOne();
 
         $result = $this->withSession(['multitenancy' => ['tenants' => $tenant->getTenantIdentifier()]])->get(route('session.route'));


### PR DESCRIPTION
This PR addresses #84 with a refactor so that service overrides are registered against services, which are arbitrary strings that represent the “service” they override.