### PR TITLE
refactor: Consolidate placeholder handling

### DIFF
--- a/src/Concerns/FindsIdentityInRouteParameter.php
+++ b/src/Concerns/FindsIdentityInRouteParameter.php
@@ -9,6 +9,7 @@ use Illuminate\Routing\RouteRegistrar;
 use Illuminate\Support\Facades\URL;
 use Sprout\Contracts\Tenancy;
 use Sprout\Contracts\Tenant;
+use Sprout\Support\PlaceholderHelper;
 
 /**
  * Find Identity in Route Parameter
@@ -96,10 +97,12 @@ trait FindsIdentityInRouteParameter
      */
     public function getRouteParameterName(Tenancy $tenancy): string
     {
-        return str_replace(
-            ['{tenancy}', '{resolver}'],
-            [$tenancy->getName(), $this->getName()],
-            $this->getParameter()
+        return PlaceholderHelper::replace(
+            $this->getParameter(),
+            [
+                'tenancy'  => $tenancy->getName(),
+                'resolver' => $this->getName(),
+            ]
         );
     }
 

--- a/src/Http/Resolvers/CookieIdentityResolver.php
+++ b/src/Http/Resolvers/CookieIdentityResolver.php
@@ -13,6 +13,7 @@ use Sprout\Contracts\Tenancy;
 use Sprout\Contracts\Tenant;
 use Sprout\Http\Middleware\TenantRoutes;
 use Sprout\Support\BaseIdentityResolver;
+use Sprout\Support\PlaceholderHelper;
 
 /**
  * Cookie Identity Resolver
@@ -91,10 +92,12 @@ final class CookieIdentityResolver extends BaseIdentityResolver
      */
     public function getRequestCookieName(Tenancy $tenancy): string
     {
-        return str_replace(
-            ['{tenancy}', '{resolver}', '{Tenancy}', '{Resolver}'],
-            [$tenancy->getName(), $this->getName(), ucfirst($tenancy->getName()), ucfirst($this->getName())],
-            $this->getCookieName()
+        return PlaceholderHelper::replace(
+            $this->getCookieName(),
+            [
+                'tenancy'  => $tenancy->getName(),
+                'resolver' => $this->getName(),
+            ]
         );
     }
 

--- a/src/Http/Resolvers/HeaderIdentityResolver.php
+++ b/src/Http/Resolvers/HeaderIdentityResolver.php
@@ -12,6 +12,7 @@ use Sprout\Contracts\Tenant;
 use Sprout\Http\Middleware\AddTenantHeaderToResponse;
 use Sprout\Http\Middleware\TenantRoutes;
 use Sprout\Support\BaseIdentityResolver;
+use Sprout\Support\PlaceholderHelper;
 
 /**
  * Header Identity Resolver
@@ -71,10 +72,12 @@ final class HeaderIdentityResolver extends BaseIdentityResolver
      */
     public function getRequestHeaderName(Tenancy $tenancy): string
     {
-        return str_replace(
-            ['{tenancy}', '{resolver}', '{Tenancy}', '{Resolver}'],
-            [$tenancy->getName(), $this->getName(), ucfirst($tenancy->getName()), ucfirst($this->getName())],
-            $this->getHeaderName()
+        return PlaceholderHelper::replace(
+            $this->getHeaderName(),
+            [
+                'tenancy'  => $tenancy->getName(),
+                'resolver' => $this->getName(),
+            ]
         );
     }
 

--- a/src/Http/Resolvers/SessionIdentityResolver.php
+++ b/src/Http/Resolvers/SessionIdentityResolver.php
@@ -13,6 +13,7 @@ use Sprout\Exceptions\CompatibilityException;
 use Sprout\Http\Middleware\TenantRoutes;
 use Sprout\Overrides\SessionOverride;
 use Sprout\Support\BaseIdentityResolver;
+use Sprout\Support\PlaceholderHelper;
 use Sprout\Support\ResolutionHook;
 use function Sprout\sprout;
 
@@ -73,10 +74,12 @@ final class SessionIdentityResolver extends BaseIdentityResolver
      */
     public function getRequestSessionName(Tenancy $tenancy): string
     {
-        return str_replace(
-            ['{tenancy}', '{resolver}', '{Tenancy}', '{Resolver}'],
-            [$tenancy->getName(), $this->getName(), ucfirst($tenancy->getName()), ucfirst($this->getName())],
-            $this->getSessionName()
+        return PlaceholderHelper::replace(
+            $this->getSessionName(),
+            [
+                'tenancy'  => $tenancy->getName(),
+                'resolver' => $this->getName(),
+            ]
         );
     }
 

--- a/src/Support/PlaceholderHelper.php
+++ b/src/Support/PlaceholderHelper.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Support;
+
+final class PlaceholderHelper
+{
+    /**
+     * @param string                                            $pattern
+     * @param array<lowercase-string, string|callable():string> $placeholders
+     *
+     * @return string
+     */
+    public static function replace(string $pattern, array $placeholders = []): string
+    {
+        $newString = $pattern;
+
+        foreach ($placeholders as $placeholder => $replacement) {
+            $newString = self::replacePlaceholder(
+                $newString,
+                $placeholder,
+                ! is_string($replacement) ? $replacement() : $replacement
+            );
+        }
+
+        return $newString;
+    }
+
+    /**
+     * @param string $string
+     * @param string $placeholder
+     * @param string $value
+     *
+     * @return string
+     */
+    private static function replacePlaceholder(string $string, string $placeholder, string $value): string
+    {
+        return str_replace(
+            [
+                '{' . strtolower($placeholder) . '}',
+                '{' . ucfirst($placeholder) . '}',
+                '{' . strtoupper($placeholder) . '}',
+            ],
+            [
+                $value,
+                ucfirst($value),
+                strtoupper($value),
+            ],
+            $string
+        );
+    }
+}


### PR DESCRIPTION
This PR adds a placeholder helper class for replacing placeholders in strings, primarily when specifying header, cookie, session, and other names for identity resolvers.

Closes #83 