### PR TITLE
feat: Add facades for all managers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,8 @@
         "Sprout\\SproutServiceProvider"
       ],
       "facades"  : [
-        "Sprout\\Facades\\Sprout"
+        "Sprout\\Facades\\Sprout",
+        "Sprout\\Facades\\Overrides"
       ]
     },
     "branch-alias": {

--- a/src/Facades/Overrides.php
+++ b/src/Facades/Overrides.php
@@ -12,6 +12,8 @@ use Sprout\Managers\ServiceOverrideManager;
 /**
  * Service Override Facade
  *
+ * This is the facade for the {@see \Sprout\Managers\ServiceOverrideManager} class.
+ *
  * @method static void bootOverrides()
  * @method static void cleanupOverrides(Tenancy $tenancy, Tenant $tenant)
  * @method static ServiceOverride|null get(string $service)
@@ -26,7 +28,7 @@ use Sprout\Managers\ServiceOverrideManager;
  * @method static void registerOverrides()
  * @method static void setupOverrides(Tenancy $tenancy, Tenant $tenant)
  */
-class Overrides extends Facade
+final class Overrides extends Facade
 {
     protected static function getFacadeAccessor(): string
     {

--- a/src/Facades/Overrides.php
+++ b/src/Facades/Overrides.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use Sprout\Contracts\ServiceOverride;
+use Sprout\Contracts\Tenancy;
+use Sprout\Contracts\Tenant;
+use Sprout\Managers\ServiceOverrideManager;
+
+/**
+ * Service Override Facade
+ *
+ * @method static void bootOverrides()
+ * @method static void cleanupOverrides(Tenancy $tenancy, Tenant $tenant)
+ * @method static ServiceOverride|null get(string $service)
+ * @method static string|null getOverrideClass(string $service)
+ * @method static array getSetupOverrides(Tenancy $tenancy)
+ * @method static bool hasOverride(string $service)
+ * @method static bool hasOverrideBeenSetUp(string $service, ?Tenancy $tenancy = null)
+ * @method static bool hasOverrideBooted(string $service)
+ * @method static bool hasTenancyBeenSetup(?Tenancy $tenancy = null)
+ * @method static bool haveOverridesBooted()
+ * @method static bool isOverrideBootable(string $service)
+ * @method static void registerOverrides()
+ * @method static void setupOverrides(Tenancy $tenancy, Tenant $tenant)
+ */
+class Overrides extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return ServiceOverrideManager::class;
+    }
+}

--- a/src/Facades/Providers.php
+++ b/src/Facades/Providers.php
@@ -26,6 +26,6 @@ final class Providers extends Facade
 {
     protected static function getFacadeAccessor(): string
     {
-        return TenantProvider::class;
+        return TenantProviderManager::class;
     }
 }

--- a/src/Facades/Providers.php
+++ b/src/Facades/Providers.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Facades;
+
+use Closure;
+use Illuminate\Support\Facades\Facade;
+use Sprout\Contracts\TenantProvider;
+use Sprout\Managers\TenantProviderManager;
+
+/**
+ * Providers Facade
+ *
+ * This is the facade for the {@see \Sprout\Managers\TenantProviderManager} class.
+ *
+ * @method static TenantProviderManager flushResolved()
+ * @method static TenantProvider get(string|null $name = null)
+ * @method static string getConfigKey(string $name)
+ * @method static string getDefaultName()
+ * @method static string getFactoryName()
+ * @method static bool hasDriver(string $name)
+ * @method static bool hasResolved(string|null $name)
+ * @method static void register(string $name, Closure $creator)
+ */
+final class Providers extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return TenantProvider::class;
+    }
+}

--- a/src/Facades/Resolvers.php
+++ b/src/Facades/Resolvers.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Facades;
+
+use Closure;
+use Illuminate\Support\Facades\Facade;
+use Sprout\Contracts\IdentityResolver;
+use Sprout\Managers\IdentityResolverManager;
+
+/**
+ * Identity Resolvers Facade
+ *
+ * This is the facade for the {@see \Sprout\Managers\IdentityResolverManager} class.
+ *
+ * @method static IdentityResolverManager flushResolved()
+ * @method static IdentityResolver get(string|null $name = null)
+ * @method static string getConfigKey(string $name)
+ * @method static string getDefaultName()
+ * @method static string getFactoryName()
+ * @method static bool hasDriver(string $name)
+ * @method static bool hasResolved(string|null $name)
+ * @method static void register(string $name, Closure $creator)
+ */
+final class Resolvers extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return IdentityResolver::class;
+    }
+}

--- a/src/Facades/Resolvers.php
+++ b/src/Facades/Resolvers.php
@@ -26,6 +26,6 @@ final class Resolvers extends Facade
 {
     protected static function getFacadeAccessor(): string
     {
-        return IdentityResolver::class;
+        return IdentityResolverManager::class;
     }
 }

--- a/src/Facades/Sprout.php
+++ b/src/Facades/Sprout.php
@@ -4,41 +4,37 @@ declare(strict_types=1);
 namespace Sprout\Facades;
 
 use Illuminate\Support\Facades\Facade;
-use Sprout\Contracts\ServiceOverride;
 use Sprout\Contracts\Tenancy;
 use Sprout\Contracts\Tenant;
 use Sprout\Managers\IdentityResolverManager;
+use Sprout\Managers\ServiceOverrideManager;
+use Sprout\Managers\TenancyManager;
 use Sprout\Managers\TenantProviderManager;
 use Sprout\Support\ResolutionHook;
+use Sprout\Support\SettingsRepository;
 
 /**
  * Sprout Facade
  *
- * @method static void bootOverrides()
- * @method static void cleanupOverrides(Tenancy $tenancy, Tenant $tenant)
  * @method static mixed config(string $key, mixed $default = null)
  * @method static array<Tenancy> getAllCurrentTenancies()
- * @method static array<ServiceOverride> getCurrentOverrides(?Tenancy $tenancy = null)
+ * @method static ResolutionHook|null getCurrentHook()
  * @method static Tenancy|null getCurrentTenancy()
- * @method static array<string, ServiceOverride> getOverrides()
- * @method static array<string> getRegisteredOverrides()
- * @method static bool hasBootedOverride(string $class)
  * @method static bool hasCurrentTenancy()
- * @method static bool hasOverride(string $class)
- * @method static bool hasRegisteredOverride(string $class)
- * @method static bool hasSetupOverride(Tenancy $tenancy, string $class)
- * @method static bool haveOverridesBooted()
- * @method static bool isBootableOverride(string $class)
+ * @method static bool isCurrentHook(ResolutionHook|null $hook)
  * @method static \Sprout\Sprout markAsInContext()
  * @method static \Sprout\Sprout markAsOutsideContext()
+ * @method static ServiceOverrideManager overrides()
  * @method static TenantProviderManager providers()
- * @method static \Sprout\Sprout registerOverride(string $class)
+ * @method static \Sprout\Sprout resetTenancies()
  * @method static IdentityResolverManager resolvers()
  * @method static string route(string $name, Tenant $tenant, string|null $resolver = null, string|null $tenancy = null, array $parameters = [], bool $absolute = true)
+ * @method static \Sprout\Sprout setCurrentHook(ResolutionHook|null $hook)
  * @method static void setCurrentTenancy(Tenancy $tenancy)
- * @method static void setupOverrides(Tenancy $tenancy, Tenant $tenant)
+ * @method static mixed setting(string $key, mixed $default = null)
+ * @method static SettingsRepository settings()
  * @method static bool supportsHook(ResolutionHook $hook)
- * @method static \Sprout\Managers\TenancyManager tenancies()
+ * @method static TenancyManager tenancies()
  * @method static bool withinContext()
  */
 final class Sprout extends Facade

--- a/src/Facades/Sprout.php
+++ b/src/Facades/Sprout.php
@@ -16,6 +16,8 @@ use Sprout\Support\SettingsRepository;
 /**
  * Sprout Facade
  *
+ * This is the facade for the {@see \Sprout\Sprout} class.
+ *
  * @method static mixed config(string $key, mixed $default = null)
  * @method static array<Tenancy> getAllCurrentTenancies()
  * @method static ResolutionHook|null getCurrentHook()

--- a/src/Facades/Tenancies.php
+++ b/src/Facades/Tenancies.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Facades;
+
+use Closure;
+use Illuminate\Support\Facades\Facade;
+use Sprout\Contracts\Tenancy;
+use Sprout\Managers\TenancyManager;
+
+/**
+ * Tenancies Facade
+ *
+ * This is the facade for the {@see \Sprout\Managers\TenancyManager} class.
+ *
+ * @method static TenancyManager flushResolved()
+ * @method static Tenancy get(string|null $name = null)
+ * @method static string getConfigKey(string $name)
+ * @method static string getDefaultName()
+ * @method static string getFactoryName()
+ * @method static bool hasDriver(string $name)
+ * @method static bool hasResolved(string|null $name)
+ * @method static void register(string $name, Closure $creator)
+ */
+final class Tenancies extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return TenancyManager::class;
+    }
+}

--- a/src/Support/BaseFactory.php
+++ b/src/Support/BaseFactory.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Sprout\Support;
 
+use Closure;
 use Illuminate\Contracts\Foundation\Application;
 use Sprout\Exceptions\MisconfigurationException;
 use Sprout\Sprout;
@@ -33,15 +34,15 @@ abstract class BaseFactory
      * Register a custom creator
      *
      * @param string                                                                    $name
-     * @param \Closure                                                                  $callback
+     * @param \Closure                                                                  $creator
      *
-     * @phpstan-param \Closure(Application, array<string, mixed>, string): FactoryClass $callback
+     * @phpstan-param \Closure(Application, array<string, mixed>, string): FactoryClass $creator
      *
      * @return void
      */
-    public static function register(string $name, \Closure $callback): void
+    public static function register(string $name, Closure $creator): void
     {
-        static::$customCreators[static::class][$name] = $callback;
+        static::$customCreators[static::class][$name] = $creator;
     }
 
     /**

--- a/tests/Unit/Facades/OverridesFacadeTest.php
+++ b/tests/Unit/Facades/OverridesFacadeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Sprout\Tests\Unit\Facades;
 
 use PHPUnit\Framework\Attributes\Test;
+use Sprout\Facades\Overrides;
 use Sprout\Facades\Sprout;
 use Sprout\Tests\Unit\UnitTestCase;
 
@@ -12,6 +13,6 @@ class OverridesFacadeTest extends UnitTestCase
     #[Test]
     public function usesCorrectInstance(): void
     {
-        $this->assertEquals(\Sprout\sprout()->overrides(), Sprout::getFacadeRoot());
+        $this->assertEquals(\Sprout\sprout()->overrides(), Overrides::getFacadeRoot());
     }
 }

--- a/tests/Unit/Facades/OverridesFacadeTest.php
+++ b/tests/Unit/Facades/OverridesFacadeTest.php
@@ -7,11 +7,11 @@ use PHPUnit\Framework\Attributes\Test;
 use Sprout\Facades\Sprout;
 use Sprout\Tests\Unit\UnitTestCase;
 
-class SproutFacadeTest extends UnitTestCase
+class OverridesFacadeTest extends UnitTestCase
 {
     #[Test]
     public function usesCorrectInstance(): void
     {
-        $this->assertEquals(\Sprout\sprout(), Sprout::getFacadeRoot());
+        $this->assertEquals(\Sprout\sprout()->overrides(), Sprout::getFacadeRoot());
     }
 }

--- a/tests/Unit/Facades/ProvidersFacadeTest.php
+++ b/tests/Unit/Facades/ProvidersFacadeTest.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Tests\Unit\Facades;
+
+use PHPUnit\Framework\Attributes\Test;
+use Sprout\Facades\Sprout;
+use Sprout\Tests\Unit\UnitTestCase;
+
+class ProvidersFacadeTest extends UnitTestCase
+{
+    #[Test]
+    public function usesCorrectInstance(): void
+    {
+        $this->assertEquals(\Sprout\sprout()->providers(), Sprout::getFacadeRoot());
+    }
+}

--- a/tests/Unit/Facades/ProvidersFacadeTest.php
+++ b/tests/Unit/Facades/ProvidersFacadeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Sprout\Tests\Unit\Facades;
 
 use PHPUnit\Framework\Attributes\Test;
+use Sprout\Facades\Providers;
 use Sprout\Facades\Sprout;
 use Sprout\Tests\Unit\UnitTestCase;
 
@@ -12,6 +13,6 @@ class ProvidersFacadeTest extends UnitTestCase
     #[Test]
     public function usesCorrectInstance(): void
     {
-        $this->assertEquals(\Sprout\sprout()->providers(), Sprout::getFacadeRoot());
+        $this->assertEquals(\Sprout\sprout()->providers(), Providers::getFacadeRoot());
     }
 }

--- a/tests/Unit/Facades/ResolversFacadeTest.php
+++ b/tests/Unit/Facades/ResolversFacadeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Sprout\Tests\Unit\Facades;
 
 use PHPUnit\Framework\Attributes\Test;
+use Sprout\Facades\Resolvers;
 use Sprout\Facades\Sprout;
 use Sprout\Tests\Unit\UnitTestCase;
 
@@ -12,6 +13,6 @@ class ResolversFacadeTest extends UnitTestCase
     #[Test]
     public function usesCorrectInstance(): void
     {
-        $this->assertEquals(\Sprout\sprout()->resolvers(), Sprout::getFacadeRoot());
+        $this->assertEquals(\Sprout\sprout()->resolvers(), Resolvers::getFacadeRoot());
     }
 }

--- a/tests/Unit/Facades/ResolversFacadeTest.php
+++ b/tests/Unit/Facades/ResolversFacadeTest.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Tests\Unit\Facades;
+
+use PHPUnit\Framework\Attributes\Test;
+use Sprout\Facades\Sprout;
+use Sprout\Tests\Unit\UnitTestCase;
+
+class ResolversFacadeTest extends UnitTestCase
+{
+    #[Test]
+    public function usesCorrectInstance(): void
+    {
+        $this->assertEquals(\Sprout\sprout()->resolvers(), Sprout::getFacadeRoot());
+    }
+}

--- a/tests/Unit/Facades/TenanciesFacadeTest.php
+++ b/tests/Unit/Facades/TenanciesFacadeTest.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Tests\Unit\Facades;
+
+use PHPUnit\Framework\Attributes\Test;
+use Sprout\Facades\Sprout;
+use Sprout\Tests\Unit\UnitTestCase;
+
+class TenanciesFacadeTest extends UnitTestCase
+{
+    #[Test]
+    public function usesCorrectInstance(): void
+    {
+        $this->assertEquals(\Sprout\sprout()->tenancies(), Sprout::getFacadeRoot());
+    }
+}

--- a/tests/Unit/Facades/TenanciesFacadeTest.php
+++ b/tests/Unit/Facades/TenanciesFacadeTest.php
@@ -5,6 +5,7 @@ namespace Sprout\Tests\Unit\Facades;
 
 use PHPUnit\Framework\Attributes\Test;
 use Sprout\Facades\Sprout;
+use Sprout\Facades\Tenancies;
 use Sprout\Tests\Unit\UnitTestCase;
 
 class TenanciesFacadeTest extends UnitTestCase
@@ -12,6 +13,6 @@ class TenanciesFacadeTest extends UnitTestCase
     #[Test]
     public function usesCorrectInstance(): void
     {
-        $this->assertEquals(\Sprout\sprout()->tenancies(), Sprout::getFacadeRoot());
+        $this->assertEquals(\Sprout\sprout()->tenancies(), Tenancies::getFacadeRoot());
     }
 }


### PR DESCRIPTION
This PR is all about facades. While I don't particularly like them, and avoid using them at all costs, I recognise that others will like them.

This PR does the following:

- Updates the `Sprout` facade to reflect the previous refactors
- Adds an `Overrides` facade for the `ServiceOverrideManager` class
- Adds a `Providers` facade for the `TenantProviderManager` class
- Adds a `Tenancies` facade for the `TenancyManager` class