### PR TITLE
feat: Add contextual attributes for Sprouts core managers

### DIFF
--- a/src/Attributes/Override.php
+++ b/src/Attributes/Override.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Attributes;
+
+use Attribute;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Container\ContextualAttribute;
+use Sprout\Contracts\ServiceOverride;
+use Sprout\Managers\ServiceOverrideManager;
+
+/**
+ * Override Attribute
+ *
+ * This is a contextual attribute that allows for the auto-injection of a
+ * service override using its registered name.
+ *
+ * @see     https://laravel.com/docs/11.x/container#contextual-attributes
+ *
+ * @package Core
+ */
+#[Attribute(Attribute::TARGET_PARAMETER)]
+final readonly class Override implements ContextualAttribute
+{
+    /**
+     * The service override to inject
+     *
+     * @var string
+     */
+    public string $service;
+
+    /**
+     * Create a new instance
+     *
+     * @param string $service
+     */
+    public function __construct(string $service)
+    {
+        $this->service = $service;
+    }
+
+    /**
+     * Resolve the tenancy using this attribute
+     *
+     * @param \Sprout\Attributes\Override     $attribute
+     * @param \Illuminate\Container\Container $container
+     *
+     * @return \Sprout\Contracts\ServiceOverride|null
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function resolve(Override $attribute, Container $container): ?ServiceOverride
+    {
+        /**
+         * It's not nullable, it'll be an exception
+         *
+         * @noinspection NullPointerExceptionInspection
+         */
+        return $container->make(ServiceOverrideManager::class)->get($this->service);
+    }
+}

--- a/src/Attributes/Provider.php
+++ b/src/Attributes/Provider.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Attributes;
+
+use Attribute;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Container\ContextualAttribute;
+use Sprout\Contracts\TenantProvider;
+use Sprout\Managers\TenantProviderManager;
+
+/**
+ * Provider Attribute
+ *
+ * This is a contextual attribute that allows for the auto-injection of a
+ * tenant provider using its registered name, or the default.
+ *
+ * @see     https://laravel.com/docs/11.x/container#contextual-attributes
+ *
+ * @package Core
+ */
+#[Attribute(Attribute::TARGET_PARAMETER)]
+final readonly class Provider implements ContextualAttribute
+{
+    /**
+     * @var string|null
+     */
+    public ?string $name;
+
+    /**
+     * Create a new instance
+     *
+     * @param string|null $name
+     */
+    public function __construct(?string $name = null)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * Resolve the tenancy using this attribute
+     *
+     * @param \Sprout\Attributes\Provider     $attribute
+     * @param \Illuminate\Container\Container $container
+     *
+     * @return \Sprout\Contracts\TenantProvider<*>|null
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws \Sprout\Exceptions\MisconfigurationException
+     */
+    public function resolve(Provider $attribute, Container $container): ?TenantProvider
+    {
+        /**
+         * It's not nullable, it'll be an exception
+         *
+         * @noinspection NullPointerExceptionInspection
+         */
+        return $container->make(TenantProviderManager::class)->get($this->name);
+    }
+}

--- a/src/Attributes/Resolver.php
+++ b/src/Attributes/Resolver.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Attributes;
+
+use Attribute;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Container\ContextualAttribute;
+use Sprout\Contracts\IdentityResolver;
+use Sprout\Managers\IdentityResolverManager;
+
+/**
+ * Resolver Attribute
+ *
+ * This is a contextual attribute that allows for the auto-injection of an
+ * identity resolver using its registered name, or the default.
+ *
+ * @see     https://laravel.com/docs/11.x/container#contextual-attributes
+ *
+ * @package Core
+ */
+#[Attribute(Attribute::TARGET_PARAMETER)]
+final readonly class Resolver implements ContextualAttribute
+{
+    /**
+     * @var string|null
+     */
+    public ?string $name;
+
+    /**
+     * Create a new instance
+     *
+     * @param string|null $name
+     */
+    public function __construct(?string $name = null)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * Resolve the tenancy using this attribute
+     *
+     * @param \Sprout\Attributes\Resolver     $attribute
+     * @param \Illuminate\Container\Container $container
+     *
+     * @return \Sprout\Contracts\IdentityResolver|null
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws \Sprout\Exceptions\MisconfigurationException
+     */
+    public function resolve(Resolver $attribute, Container $container): ?IdentityResolver
+    {
+        /**
+         * It's not nullable, it'll be an exception
+         *
+         * @noinspection NullPointerExceptionInspection
+         */
+        return $container->make(IdentityResolverManager::class)->get($this->name);
+    }
+}

--- a/src/Attributes/Tenancy.php
+++ b/src/Attributes/Tenancy.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Attributes;
+
+use Attribute;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Container\ContextualAttribute;
+use Sprout\Contracts\Tenancy as TenancyContract;
+use Sprout\Managers\TenancyManager;
+
+/**
+ * Tenancy Attribute
+ *
+ * This is a contextual attribute that allows for the auto-injection of the
+ * tenancy, either using its registered name or the default.
+ *
+ * @see     https://laravel.com/docs/11.x/container#contextual-attributes
+ *
+ * @package Core
+ */
+#[Attribute(Attribute::TARGET_PARAMETER)]
+final readonly class Tenancy implements ContextualAttribute
+{
+    /**
+     * @var string|null
+     */
+    public ?string $name;
+
+    /**
+     * Create a new instance
+     *
+     * @param string|null $name
+     */
+    public function __construct(?string $name = null)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * Resolve the tenancy using this attribute
+     *
+     * @param \Sprout\Attributes\Tenancy      $attribute
+     * @param \Illuminate\Container\Container $container
+     *
+     * @return \Sprout\Contracts\Tenancy<*>|null
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws \Sprout\Exceptions\MisconfigurationException
+     */
+    public function resolve(Tenancy $attribute, Container $container): ?TenancyContract
+    {
+        /**
+         * It's not nullable, it'll be an exception
+         *
+         * @noinspection NullPointerExceptionInspection
+         */
+        return $container->make(TenancyManager::class)->get($this->name);
+    }
+}

--- a/src/Support/BaseFactory.php
+++ b/src/Support/BaseFactory.php
@@ -221,13 +221,13 @@ abstract class BaseFactory
      *
      * @param string|null $name
      *
-     * @return object|null
+     * @return object
      *
      * @phpstan-return FactoryClass
      *
      * @throws \Sprout\Exceptions\MisconfigurationException
      */
-    public function get(?string $name = null): ?object
+    public function get(?string $name = null): object
     {
         $name ??= $this->getDefaultName();
 
@@ -235,7 +235,7 @@ abstract class BaseFactory
             $this->objects[$name] = $this->resolve($name);
         }
 
-        return $this->objects[$name] ?? null;
+        return $this->objects[$name];
     }
 
     /**

--- a/src/Support/BaseFactory.php
+++ b/src/Support/BaseFactory.php
@@ -221,13 +221,13 @@ abstract class BaseFactory
      *
      * @param string|null $name
      *
-     * @return object
+     * @return object|null
      *
      * @phpstan-return FactoryClass
      *
      * @throws \Sprout\Exceptions\MisconfigurationException
      */
-    public function get(?string $name = null): object
+    public function get(?string $name = null): ?object
     {
         $name ??= $this->getDefaultName();
 
@@ -235,7 +235,7 @@ abstract class BaseFactory
             $this->objects[$name] = $this->resolve($name);
         }
 
-        return $this->objects[$name];
+        return $this->objects[$name] ?? null;
     }
 
     /**

--- a/tests/Unit/Attributes/OverrideTest.php
+++ b/tests/Unit/Attributes/OverrideTest.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Tests\Unit\Attributes;
+
+use Illuminate\Config\Repository;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
+use PHPUnit\Framework\Attributes\Test;
+use Sprout\Attributes\CurrentTenant;
+use Sprout\Attributes\Override;
+use Sprout\Contracts\ServiceOverride;
+use Sprout\Managers\ServiceOverrideManager;
+use Sprout\Support\GenericTenant;
+use Sprout\Tests\Unit\UnitTestCase;
+use Workbench\App\Models\TenantModel;
+use function Sprout\sprout;
+use function Sprout\tenancy;
+
+class OverrideTest extends UnitTestCase
+{
+    #[Test]
+    public function resolvesServiceOverrides(): void
+    {
+        $manager = $this->app->make(ServiceOverrideManager::class);
+
+        $callback1 = static function (#[Override('session')] ServiceOverride $override) {
+            return $override;
+        };
+
+        $callback2 = static function (#[Override('filesystem')] ServiceOverride $override) {
+            return $override;
+        };
+
+        $this->assertSame($manager->get('session'), $this->app->call($callback1));
+        $this->assertSame($manager->get('filesystem'), $this->app->call($callback2));
+    }
+}

--- a/tests/Unit/Attributes/ProviderTest.php
+++ b/tests/Unit/Attributes/ProviderTest.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Tests\Unit\Attributes;
+
+use PHPUnit\Framework\Attributes\Test;
+use Sprout\Attributes\Provider;
+use Sprout\Attributes\Tenancy;
+use Sprout\Contracts\TenantProvider;
+use Sprout\Managers\TenancyManager;
+use Sprout\Managers\TenantProviderManager;
+use Sprout\Tests\Unit\UnitTestCase;
+use Workbench\App\Models\TenantModel;
+
+class ProviderTest extends UnitTestCase
+{
+    protected function defineEnvironment($app)
+    {
+        tap($app['config'], function ($config) {
+            $config->set('multitenancy.providers.tenants.model', TenantModel::class);
+
+            $config->set('multitenancy.providers.backup', [
+                'driver' => 'database',
+                'table'  => 'tenants',
+            ]);
+        });
+    }
+
+    #[Test]
+    public function resolvesTenantProvider(): void
+    {
+        $manager = $this->app->make(TenantProviderManager::class);
+
+        $callback1 = static function (#[Provider] TenantProvider $provider) {
+            return $provider;
+        };
+
+        $callback2 = static function (#[Provider('backup')] TenantProvider $provider) {
+            return $provider;
+        };
+
+        $this->assertSame($manager->get(), $this->app->call($callback1));
+        $this->assertSame($manager->get('backup'), $this->app->call($callback2));
+    }
+}

--- a/tests/Unit/Attributes/ResolverTest.php
+++ b/tests/Unit/Attributes/ResolverTest.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Tests\Unit\Attributes;
+
+use PHPUnit\Framework\Attributes\Test;
+use Sprout\Attributes\Override;
+use Sprout\Attributes\Resolver;
+use Sprout\Contracts\IdentityResolver;
+use Sprout\Contracts\ServiceOverride;
+use Sprout\Managers\IdentityResolverManager;
+use Sprout\Managers\ServiceOverrideManager;
+use Sprout\Tests\Unit\UnitTestCase;
+use Workbench\App\Models\TenantModel;
+
+class ResolverTest extends UnitTestCase
+{
+    protected function defineEnvironment($app)
+    {
+        tap($app['config'], static function ($config) {
+            $config->set('multitenancy.resolvers.subdomain.domain', 'localhost');
+        });
+    }
+
+    #[Test]
+    public function resolvesIdentityResolver(): void
+    {
+        $manager = $this->app->make(IdentityResolverManager::class);
+
+        $callback1 = static function (#[Resolver] IdentityResolver $resolver) {
+            return $resolver;
+        };
+
+        $callback2 = static function (#[Resolver('subdomain')] IdentityResolver $resolver) {
+            return $resolver;
+        };
+
+        $this->assertSame($manager->get(), $this->app->call($callback1));
+        $this->assertSame($manager->get('subdomain'), $this->app->call($callback2));
+    }
+}

--- a/tests/Unit/Attributes/TenancyTest.php
+++ b/tests/Unit/Attributes/TenancyTest.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Tests\Unit\Attributes;
+
+use PHPUnit\Framework\Attributes\Test;
+use Sprout\Attributes\Tenancy;
+use Sprout\Managers\TenancyManager;
+use Sprout\Tests\Unit\UnitTestCase;
+use Workbench\App\Models\TenantModel;
+
+class TenancyTest extends UnitTestCase
+{
+    protected function defineEnvironment($app)
+    {
+        tap($app['config'], function ($config) {
+            $config->set('multitenancy.providers.tenants.model', TenantModel::class);
+
+            $config->set('multitenancy.providers.backup', [
+                'driver' => 'database',
+                'table'  => 'tenants',
+            ]);
+
+            $config->set('multitenancy.tenancies.backup', [
+                'provider' => 'backup',
+            ]);
+        });
+    }
+
+    #[Test]
+    public function resolvesTenancy(): void
+    {
+        $manager = $this->app->make(TenancyManager::class);
+
+        $callback1 = static function (#[Tenancy] \Sprout\Contracts\Tenancy $tenancy) {
+            return $tenancy;
+        };
+
+        $callback2 = static function (#[Tenancy('backup')] \Sprout\Contracts\Tenancy $tenancy) {
+            return $tenancy;
+        };
+
+        $this->assertSame($manager->get(), $this->app->call($callback1));
+        $this->assertSame($manager->get('backup'), $this->app->call($callback2));
+    }
+}


### PR DESCRIPTION
This PR adds contextual attributes for identity resolvers, service overrides, tenant providers and tenancies, using their respective managers.