### PR TITLE
refactor(eloquent.resources): Allow for overriding of resource key

### DIFF
--- a/src/Database/Eloquent/Concerns/HasTenantResources.php
+++ b/src/Database/Eloquent/Concerns/HasTenantResources.php
@@ -33,10 +33,22 @@ trait HasTenantResources
             if ($model->getAttribute($model->getTenantResourceKeyName()) === null) {
                 $model->setAttribute(
                     $model->getTenantResourceKeyName(),
-                    Str::uuid()
+                    method_exists($model, 'generateNewResourceKey')
+                        ? $model->generateNewResourceKey()
+                        : Str::uuid()
                 );
             }
         });
+    }
+
+    /**
+     * Generate a new resource key
+     *
+     * @return mixed
+     */
+    public function generateNewResourceKey(): mixed
+    {
+        return Str::uuid();
     }
 
     /**


### PR DESCRIPTION
This PR addresses #105, and instead of making ULIDs the default, it allows you to change how the keys are generated by overriding `generateNewResourceKey`.