### PR TITLE
chore: Ensure stacked service overrides are booted

### DIFF
--- a/src/Overrides/StackedOverride.php
+++ b/src/Overrides/StackedOverride.php
@@ -10,6 +10,7 @@ use Sprout\Contracts\BootableServiceOverride;
 use Sprout\Contracts\ServiceOverride;
 use Sprout\Contracts\Tenancy;
 use Sprout\Contracts\Tenant;
+use Sprout\Events\ServiceOverrideBooted;
 use Sprout\Exceptions\MisconfigurationException;
 use Sprout\Sprout;
 
@@ -52,7 +53,7 @@ final class StackedOverride extends BaseOverride implements BootableServiceOverr
      * @param Tenancy<TenantClass> $tenancy
      * @param Tenant               $tenant
      *
-     * @phpstan-param TenantClass                         $tenant
+     * @phpstan-param TenantClass  $tenant
      *
      * @return void
      */
@@ -108,6 +109,8 @@ final class StackedOverride extends BaseOverride implements BootableServiceOverr
         foreach ($this->overrides as $override) {
             if ($override instanceof BootableServiceOverride) {
                 $override->boot($app, $sprout);
+
+                ServiceOverrideBooted::dispatch($this->service, $override);
             }
         }
     }
@@ -128,7 +131,7 @@ final class StackedOverride extends BaseOverride implements BootableServiceOverr
      * @param Tenancy<TenantClass> $tenancy
      * @param Tenant               $tenant
      *
-     * @phpstan-param TenantClass                         $tenant
+     * @phpstan-param TenantClass  $tenant
      *
      * @return void
      */

--- a/tests/Unit/Overrides/StackedOverrideTest.php
+++ b/tests/Unit/Overrides/StackedOverrideTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 namespace Sprout\Tests\Unit\Overrides;
 
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\Facades\Event;
 use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
+use Sprout\Events\ServiceOverrideBooted;
 use Sprout\Exceptions\MisconfigurationException;
 use Sprout\Overrides\Auth\AuthGuardOverride;
 use Sprout\Overrides\Auth\AuthPasswordOverride;
+use Sprout\Overrides\Auth\TenantConfigAuthManagerOverride;
 use Sprout\Overrides\StackedOverride;
 use Sprout\Sprout;
 use Sprout\Support\SettingsRepository;
@@ -219,5 +222,59 @@ class StackedOverrideTest extends UnitTestCase
         $this->assertInstanceOf(AuthGuardOverride::class, $overrides[AuthGuardOverride::class]);
         $this->assertSame(['test1' => 'value1'], $overrides[AuthPasswordOverride::class]->getConfig());
         $this->assertSame(['test2' => 'value2'], $overrides[AuthGuardOverride::class]->getConfig());
+    }
+
+    #[Test]
+    public function firesTheBootEventForEveryBootableChild(): void
+    {
+        Event::fake([ServiceOverrideBooted::class]);
+
+        $app = \Mockery::mock(Application::class, static function (MockInterface $mock) {
+            $mock->shouldNotReceive('make');
+            $mock->shouldIgnoreMissing();
+        });
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        // Two bootable children, and one that isn't bootable
+        $password    = new AuthPasswordOverride('test', []);
+        $authManager = new TenantConfigAuthManagerOverride('test', []);
+        $guard       = new AuthGuardOverride('test', []);
+
+        $override = new StackedOverride('test', [
+            'overrides' => [
+                $password,
+                $authManager,
+                $guard,
+            ],
+        ]);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        // All three children should have been created
+        $this->assertCount(3, $override->getOverrides());
+
+        // The boot event should fire exactly once for each bootable child
+        Event::assertDispatchedTimes(ServiceOverrideBooted::class, 2);
+
+        Event::assertDispatched(
+            ServiceOverrideBooted::class,
+            static fn (ServiceOverrideBooted $event): bool => $event->service === 'test'
+                && $event->override === $password
+        );
+
+        Event::assertDispatched(
+            ServiceOverrideBooted::class,
+            static fn (ServiceOverrideBooted $event): bool => $event->service === 'test'
+                && $event->override === $authManager
+        );
+
+        // ...but never for the child that isn't bootable
+        Event::assertNotDispatched(
+            ServiceOverrideBooted::class,
+            static fn (ServiceOverrideBooted $event): bool => $event->override === $guard
+        );
     }
 }


### PR DESCRIPTION
The ServiceOverrideBooted event fired after each bootable override is booted, but when running the StackedOverride, it only fires once for the stack. It now fires once for each bootable child override, and then once for the stacked override.

This PR fixes #117 